### PR TITLE
Remove unused xcodeproj

### DIFF
--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
### Motivation

Forgotten xcodeproj is redundant and should be deleted.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docu has been updated (if applicable)
- [X] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?