### PR TITLE
Fix: prevent usage of both preview and secured API keys together

### DIFF
--- a/Example/Tests/DeliveryService/DeliveryClient/InitDeliveryClient.swift
+++ b/Example/Tests/DeliveryService/DeliveryClient/InitDeliveryClient.swift
@@ -1,0 +1,46 @@
+//
+//  InitDeliveryClient.swift
+//  KenticoCloud_Example
+//
+//  Created by Sagar Choudhary on 03/10/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+import KenticoCloud
+
+class InitDeliveryClient: QuickSpec {
+    override func spec() {
+        describe("Initialize Delivery client") {
+            
+            context("Initializing with no API key") {
+                
+                it("does not throw Assertion fatalError()") {
+                    expect {_ = DeliveryClient.init(projectId: TestConstants.projectId)}.toNot(throwAssertion())
+                }
+            }
+            
+            context("Initializing with secure API key only ") {
+                
+                it("does not throw Assertion fatalError()") {
+                    expect {_ = DeliveryClient.init(projectId: TestConstants.projectId, secureApiKey: TestConstants.secureApiKey)}.toNot(throwAssertion())
+                }
+            }
+            
+            context("Initializing with Preview API key only ") {
+                
+                it("does not throw Assertion fatalError()") {
+                    expect {_ = DeliveryClient.init(projectId: TestConstants.projectId, previewApiKey: TestConstants.previewApiKey)}.toNot(throwAssertion())
+                }
+            }
+            
+            context("Initializing with both secure and preview API key") {
+                
+                it("throw Assertion fatalError()") {
+                    expect {_ = DeliveryClient.init(projectId: TestConstants.projectId, previewApiKey: TestConstants.previewApiKey, secureApiKey: TestConstants.secureApiKey)}.to(throwAssertion())
+                }
+            }
+        }
+    }
+}

--- a/KenticoCloud/Classes/DeliveryService/DeliveryClient.swift
+++ b/KenticoCloud/Classes/DeliveryService/DeliveryClient.swift
@@ -34,6 +34,11 @@ public class DeliveryClient {
      */
     public init(projectId: String, previewApiKey: String? = nil, secureApiKey: String? = nil, enableDebugLogging: Bool = false,
                 isRetryEnabled: Bool = true, maxRetryAttempts: Int = 5) {
+        
+        // checks if both secure and Preview API keys are present
+        if secureApiKey != nil && previewApiKey != nil {
+            fatalError("Preview API and Secured Production API can't be used at the same time.")
+        }
         self.projectId = projectId
         self.previewApiKey = previewApiKey
         self.secureApiKey = secureApiKey


### PR DESCRIPTION
Fixes Issue #47 

### Checklist
- [x] Code follows coding conventions held in this repo
- [x] Add Automated Tests
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

if we try initializing a client with both previews and secured API key it throws out fatalError telling that both cannot be used together.
